### PR TITLE
Changed guard "TL_DECL_MUTEX" to "TL_TRAITS_MUTEX"

### DIFF
--- a/function_ref.hpp
+++ b/function_ref.hpp
@@ -62,7 +62,8 @@
 
 namespace tl {
 namespace detail {
-#ifndef TL_DECL_MUTEX
+#ifndef TL_TRAITS_MUTEX
+#define TL_TRAITS_MUTEX
 // C++14-style aliases for brevity
 template <class T> using remove_const_t = typename std::remove_const<T>::type;
 template <class T>


### PR DESCRIPTION
If using in the same file `tl::function_ref` and one of `tl::optional` or `tl::expected`, `tl::detail::invoke` is defined two times because of the different guards: so a simple program like
```cpp
#include <tl/optional.hpp>
#include <tl/function_ref.hpp>

int main()
{
    auto x = [](int i){ return 41 + i; };
    tl::detail::invoke(x, 1);
}
```
can't compile on GCC and Clang.
Now it should compile correctly.