### PR TITLE
Silence warnings about unused variables in the tests

### DIFF
--- a/tests/constructors.cpp
+++ b/tests/constructors.cpp
@@ -7,7 +7,7 @@ struct bar {
 };
 
 TEST_CASE("Constructors", "[constructors]") {
-    tl::function_ref<void(void)> fr1 = [] {};
+    tl::function_ref<void(void)> fr1 = []{};
     tl::function_ref<void(void)> fr2 = foo;
     tl::function_ref<void(bar)> fr3 = &bar::baz;
 

--- a/tests/constructors.cpp
+++ b/tests/constructors.cpp
@@ -1,13 +1,20 @@
 #include "catch.hpp"
 #include "function_ref.hpp"
 
-void foo(){}
-struct bar {
-    void baz(){}
+void foo() {}
+struct bar
+{
+    void baz() {}
 };
 
-TEST_CASE("Constructors", "[constructors]") {
-    tl::function_ref<void(void)> fr1 = []{};
+TEST_CASE("Constructors", "[constructors]")
+{
+    tl::function_ref<void(void)> fr1 = [] {};
     tl::function_ref<void(void)> fr2 = foo;
     tl::function_ref<void(bar)> fr3 = &bar::baz;
+
+    // Silence warnings
+    (void)fr1;
+    (void)fr2;
+    (void)fr3;
 }

--- a/tests/constructors.cpp
+++ b/tests/constructors.cpp
@@ -1,14 +1,12 @@
 #include "catch.hpp"
 #include "function_ref.hpp"
 
-void foo() {}
-struct bar
-{
-    void baz() {}
+void foo(){}
+struct bar {
+    void baz(){}
 };
 
-TEST_CASE("Constructors", "[constructors]")
-{
+TEST_CASE("Constructors", "[constructors]") {
     tl::function_ref<void(void)> fr1 = [] {};
     tl::function_ref<void(void)> fr2 = foo;
     tl::function_ref<void(bar)> fr3 = &bar::baz;

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -2,6 +2,7 @@
 #include "function_ref.hpp"
 
 TEST_CASE("Issue #2") {
-	const auto lam = [](int x) {};
+	const auto lam = [](int ) {};
 	tl::function_ref<void(int)> ref = lam;
+	(void)ref;
 }


### PR DESCRIPTION
Hi @TartanLlama 
Thanks for this library. We had a few warnings in the unit tests - which this patch should fix.
