### PR TITLE
CMake: add subproject detection and fix source location.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,15 @@
 cmake_minimum_required(VERSION 3.0)
 
+# Determine if we are building as part of a parent project.
+get_directory_property(is_subproject PARENT_DIRECTORY)
+
 project(function_ref)
 
+add_library(function_ref INTERFACE)
+target_sources(function_ref INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/function_ref.hpp)
+target_include_directories(function_ref INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(NOT is_subproject)
 # Prepare "Catch" library for other executables
 set(CATCH_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/test)
 add_library(Catch INTERFACE)
@@ -16,10 +24,6 @@ set(TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tests/main.cpp
 
 add_executable(tests ${TEST_SOURCES})
 
-add_library(function_ref INTERFACE)
-target_sources(function_ref INTERFACE ${CMAKE_SOURCE_DIR}/function_ref.hpp)
-target_include_directories(function_ref INTERFACE ${CMAKE_SOURCE_DIR})
-
 target_link_libraries(tests Catch function_ref)
 set_property(TARGET tests PROPERTY CXX_STANDARD 14)
 
@@ -32,4 +36,5 @@ standardese_generate(function_ref
                      INCLUDE_DIRECTORY .
                      CONFIG ${CMAKE_SOURCE_DIR}/standardese.config
                      INPUT function_ref.hpp)
+endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,12 @@ cmake_minimum_required(VERSION 3.11)
 
 project(tl-function_ref VERSION 1.0.0 LANGUAGES CXX)
 
-option(FUNCTION_REF_ENABLE_TESTS "Enable tests." ON)
+get_directory_property(is_subproject PARENT_DIRECTORY)
+if(NOT is_subproject)
+  set(is_mainproject YES)
+endif()
+
+option(FUNCTION_REF_ENABLE_TESTS "Enable tests." ${is_mainproject})
 
 include(FetchContent)
 FetchContent_Declare(


### PR DESCRIPTION
The subproject detection avoids adding things into the build that
are not necessary (i.e., standardese, unit tests) and/or may
cause conflicts (i.e., `tests` target name) when building as a
submodule in a parent project.

Also change `CMAKE_SOURCE_LOCATION` --> `CMAKE_CURRENT_SOURCE_LOCATION`
which is more correct and is needed when the source location is
not the top level folder in the project.