### PR TITLE
Enable tests by default only when not a subproject.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,12 @@ cmake_minimum_required(VERSION 3.11)
 
 project(tl-function_ref VERSION 1.0.0 LANGUAGES CXX)
 
-option(FUNCTION_REF_ENABLE_TESTS "Enable tests." ON)
+get_directory_property(is_subproject PARENT_DIRECTORY)
+if(NOT is_subproject)
+  set(is_mainproject YES)
+endif()
+
+option(FUNCTION_REF_ENABLE_TESTS "Enable tests." ${is_mainproject})
 
 include(FetchContent)
 FetchContent_Declare(


### PR DESCRIPTION
This way, function_ref testing is opt-in when in the
context of a parent project as opposed to being on by
default, which is frequently not desirable.