### PR TITLE
Bugfix/issue 20 allow non copyable non movable return types

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,21 @@
 os:
-- Visual Studio 2015
-- Visual Studio 2017
+  - Visual Studio 2017
+  - Visual Studio 2015
+
+environment:
+  matrix:
+    - STD: 17
+    - STD: 14
 
 build_script:
   - git submodule update --init --recursive
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake -DCMAKE_CXX_STANDARD=%STD% -DCMAKE_CXX_STANDARD_REQUIRED=True ..
   - cmake --build .
   - C:\projects\function-ref\build\Debug\tests.exe
+
+matrix:
+  exclude:
+    - os: Visual Studio 2015
+      STD: 17

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ matrix:
       addons:
         apt:
           sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env: COMPILER=g++-7 CXX_STANDARD=17
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
              - ubuntu-toolchain-r-test
           packages:
              - g++-5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ option(FUNCTION_REF_ENABLE_TESTS "Enable tests." ON)
 include(FetchContent)
 FetchContent_Declare(
   tl_cmake
-  GIT_REPOSITORY https://github.com/TartanLlama/tl-cmake.git
+  GIT_REPOSITORY https://github.com/burnpanck/tl-cmake.git
+  GIT_TAG b6fe9104d205cf04c4aac3824c2d310959b66120
 )
 FetchContent_GetProperties(tl_cmake)
 if(NOT tl_cmake_POPULATED)
@@ -16,7 +17,7 @@ if(NOT tl_cmake_POPULATED)
 endif()
 include(add-tl)
 
-tl_add_library(function-ref SOURCES 
+tl_add_library(function-ref ARCH_INDEPENDENT SOURCES 
                include/tl/function_ref.hpp)
 
 # Prepare "Catch" library for other executables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,12 @@ include(add-tl)
 tl_add_library(function-ref ARCH_INDEPENDENT SOURCES 
                include/tl/function_ref.hpp)
 
+# make sure we see the C++ version, even in MSVC:
+# https://stackoverflow.com/questions/57102212/cannot-set-cplusplus-to-c17-standard-with-visual-studio-and-cmake
+if ((MSVC) AND (MSVC_VERSION GREATER_EQUAL 1914))
+  target_compile_options(function-ref INTERFACE "/Zc:__cplusplus")
+endif()
+
 # Prepare "Catch" library for other executables
 set(CATCH_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test)
 add_library(Catch INTERFACE)
@@ -37,5 +43,8 @@ if(FUNCTION_REF_ENABLE_TESTS)
   
   target_link_libraries(tests Catch function-ref)
 
-  set_property(TARGET tests PROPERTY CXX_STANDARD 14)
+  message(STATUS "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
+  if(NOT CMAKE_CXX_STANDARD)
+    set_property(TARGET tests PROPERTY CXX_STANDARD 14)
+  endif()
 endif()

--- a/include/tl/function_ref.hpp
+++ b/include/tl/function_ref.hpp
@@ -109,12 +109,20 @@ using invoke_result = invoke_result_impl<F, void, Us...>;
 template <class F, class... Us>
 using invoke_result_t = typename invoke_result<F, Us...>::type;
 
+#if __cplusplus >= 201703
+template <typename From, typename To>
+using is_prvalue_convertible = std::bool_constant<std::is_same_v<From,To> || std::is_convertible_v<From,To>>;
+#else
+template <typename From, typename To>
+using is_prvalue_convertible = std::is_convertible<From,To>;
+#endif
+
 template <class, class R, class F, class... Args>
 struct is_invocable_r_impl : std::false_type {};
 
 template <class R, class F, class... Args>
 struct is_invocable_r_impl<
-    typename std::is_convertible<invoke_result_t<F, Args...>, R>::type, R, F, Args...>
+    typename is_prvalue_convertible<invoke_result_t<F, Args...>, R>::type, R, F, Args...>
     : std::true_type {};
 
 template <class R, class F, class... Args>

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -30,3 +30,19 @@ TEST_CASE("Issue #10") {
   auto f = [&](const std::vector<int> i) { return i[0] * z; };
   foo(f);
 }
+
+#if __cplusplus >= 201703
+struct NonCopyNonMove {
+  NonCopyNonMove() = default;
+  NonCopyNonMove(const NonCopyNonMove &) = delete;
+  NonCopyNonMove(NonCopyNonMove &&) = delete;
+};
+
+TEST_CASE("Issue #20") {
+  auto f = []() { return NonCopyNonMove(); };
+  auto fr = tl::function_ref<NonCopyNonMove()>(f);
+
+  // silence warnings
+  (void)fr;
+}
+#endif


### PR DESCRIPTION
This should fix issue #20, by allowing functions that either return a convertible return type or the exact same return type (where mandatory move/copy ellision will kick in).